### PR TITLE
Shallow clone imported object

### DIFF
--- a/src/rule.ts
+++ b/src/rule.ts
@@ -19,7 +19,7 @@ export class Rule {
   private input: Record<string, any> | string | number | undefined
   private rule: any
   private validator!: Validator
-  static rules: any = { ...rules }
+  static rules: any = Object.assign({}, rules)
 
   constructor(name: string, fn: VoidFunction, async: boolean) {
     this.name = name

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -19,7 +19,7 @@ export class Rule {
   private input: Record<string, any> | string | number | undefined
   private rule: any
   private validator!: Validator
-  static rules: any = rules
+  static rules: any = { ...rules }
 
   constructor(name: string, fn: VoidFunction, async: boolean) {
     this.name = name


### PR DESCRIPTION
This pull request fixes a bug that occurrs when using Vite as the bundler.
validatorjs crashes in `rule.js` line 294 where the `register` method appends the `rules` object.
The `rules` object, however, is an imported object that is not extensible:

Error Message:
`TypeError: Cannot add property file, object is not extensible`